### PR TITLE
Check tweet json for rouge newlines to handle multiple json objects

### DIFF
--- a/src/TwitterStream.php
+++ b/src/TwitterStream.php
@@ -30,20 +30,20 @@ class TwitterStream
 
         while (!$this->streamConnection->eof()) {
             $char = $this->streamConnection->read(2);
-            $input = $char;
+            $tweets = $char;
 
             while ($char !== "\r\n") {
                 $char = $this->streamConnection->read(2);
-                $input .= $char;
+                $tweets .= $char;
             }
 
-            $input = trim($input);
+            $tweets = trim($tweets);
 
-            if (empty($input)) {
+            if (empty($tweets)) {
                 continue;
             }
 
-            $tweets = explode("\r\n", $input);
+            $tweets = explode("\r\n", $tweets);
             foreach($tweets AS $tweet) {
                 yield json_decode($tweet, true, 512, JSON_THROW_ON_ERROR);
             }

--- a/src/TwitterStream.php
+++ b/src/TwitterStream.php
@@ -29,21 +29,24 @@ class TwitterStream
         $this->streamConnection = $this->connectToFilteredStream($sets);
 
         while (!$this->streamConnection->eof()) {
-            $char  = $this->streamConnection->read(2);
-            $tweet = $char;
+            $char = $this->streamConnection->read(2);
+            $input = $char;
 
             while ($char !== "\r\n") {
                 $char = $this->streamConnection->read(2);
-                $tweet .= $char;
+                $input .= $char;
             }
 
-            $tweet = trim($tweet);
+            $input = trim($input);
 
-            if (empty($tweet)) {
+            if (empty($input)) {
                 continue;
             }
 
-            yield json_decode($tweet, true, 512, JSON_THROW_ON_ERROR);
+            $tweets = explode("\r\n", $input);
+            foreach($tweets AS $tweet) {
+                yield json_decode($tweet, true, 512, JSON_THROW_ON_ERROR);
+            }
         }
     }
 


### PR DESCRIPTION
Adding a second check for newlines helps fix issue with multiple json objects trying to be parsed by `json_decode`

Fixes #1 