### PR TITLE
Fix undefined tag error

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -33,7 +33,7 @@ class Rule
         $rules = static::ensureHttpClientIsLoaded()->request('GET', 'https://api.twitter.com/2/tweets/search/stream/rules');
 
         return array_map(static function ($rawRule) {
-            $rule = new self($rawRule['value'], $rawRule['tag']);
+            $rule = new self($rawRule['value'], $rawRule['tag'] ?? '');
             $rule->withId($rawRule['id']);
 
             return $rule;


### PR DESCRIPTION
When we manually save rules WITHOUT the tag outside this library or when there are existing rules, the library throws undefined "tag" error when some of the rules don't have the tag in the response. 

This PR fixes that error with a simple check.