### PR TITLE
Fix logic operands + Twitter error response message

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ composer require redwebcreation/twitter-stream-api
 
 ```php
 use RWC\TwitterStream\Connection;
-use RWC\TwitterStream\TwitterStream;
+use RWC\TwitterStream\FilteredStream;
+use RWC\TwitterStream\VolumeStream;
 
-$twitterStream  = new TwitterStream();
+$twitterStream  = new FilteredStream();
+// or
+$twitterStream  = new VolumeStream();
+
 $connection     = new Connection(
    bearerToken: '...'
 );

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ $rule->new(tag: 'cat_filter_1')
 
 $twitterStream
     ->backfill(2) // for "academic research" accounts only
-    ->expansions(['author_id'])
-    ->fields(['media.duration_ms', 'media.height'])
-    ->fields(['place.full_name', 'place.geo', 'place.id'])
+    ->expansions('author_id')
+    ->fields('media.duration_ms', 'media.height')
+    ->fields('place.full_name', 'place.geo', 'place.id')
     ->listen($connection, function (array $tweet) {
         echo $tweet['data']['text'];
         
@@ -59,7 +59,7 @@ Tweets your stream receives. Rules are saved by Twitter and are persistent.
 ### Client
 
 ```php
-use RWC\TwitterStream\RuleBuilder;
+use RWC\TwitterStream\RuleManager;
 
 $rules = new RuleManager($connection);
 ```
@@ -142,8 +142,9 @@ You can also group operators together :
 
 ```php
 use RWC\TwitterStream\RuleBuilder;
+
 $rules->query('#laravel')
-    ->group(function (RluleBuilder $builder) {
+    ->group(function (RuleBuilder $builder) {
         $builder->raw('tip')->or->raw('tips')->or->raw('🔥');
     });
 

--- a/src/Exceptions/TwitterException.php
+++ b/src/Exceptions/TwitterException.php
@@ -34,7 +34,9 @@ class TwitterException extends Exception
             // For most errors related to rule creation, details are provided.
             $hasDetails = array_key_exists('details', $error);
 
-            $buffer .= sprintf("[%s] %s %s [%s]\n", $error['title'], $error['value'], $hasDetails ? ': ' . implode('; ', $error['details']) : '', $error['id']);
+            $errorIdOrType = $error['id'] ?? ($error['type'] ?? '');
+
+            $buffer .= sprintf("[%s] %s %s [%s]\n", $error['title'], $error['value'], $hasDetails ? ': ' . implode('; ', $error['details']) : '', $errorIdOrType);
         }
 
         return new self(

--- a/src/Exceptions/TwitterException.php
+++ b/src/Exceptions/TwitterException.php
@@ -34,7 +34,7 @@ class TwitterException extends Exception
             // For most errors related to rule creation, details are provided.
             $hasDetails = array_key_exists('details', $error);
 
-            $errorIdOrType = $error['id'] ?? ($error['type'] ?? '');
+            $errorIdOrType = $error['id'] ?? ($error['type'] ?? 'Generic Problem');
 
             $buffer .= sprintf("[%s] %s %s [%s]\n", $error['title'], $error['value'], $hasDetails ? ': ' . implode('; ', $error['details']) : '', $errorIdOrType);
         }

--- a/src/Operators/GroupOperator.php
+++ b/src/Operators/GroupOperator.php
@@ -35,7 +35,7 @@ class GroupOperator extends Operator
                 }
 
                 $stack->add($index, new RawOperator([
-                    Flag::has($this->flags, self::OR_OPERATOR) ? 'or' : 'and',
+                    Flag::has($this->flags, self::OR_OPERATOR) ? 'OR' : 'AND',
                 ]));
             }
 

--- a/src/RuleBuilder.php
+++ b/src/RuleBuilder.php
@@ -49,8 +49,8 @@ class RuleBuilder extends _RuleBuilder
     public function __get(string $name): self
     {
         match ($name) {
-            'and' => $this->push(new RawOperator(['and'])),
-            'or'  => $this->push(new RawOperator(['or'])),
+            'and' => $this->push(new RawOperator(['AND'])),
+            'or'  => $this->push(new RawOperator(['OR'])),
             /* @see https://wiki.php.net/rfc/undefined_property_error_promotion */
             default => trigger_error('Undefined property: ' . static::class . '::$' . $name, PHP_MAJOR_VERSION === 8 ? E_USER_WARNING : E_USER_ERROR)
         };

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -34,33 +34,33 @@ it('can compile a query with mixed negated and non-negated operators', function 
 });
 
 it('can compile a query with operators linked by OR', function () {
-    expect(query('php')->lang('en')->or->has('images')->compile())->toBe('php lang:en or has:images');
+    expect(query('php')->lang('en')->or->has('images')->compile())->toBe('php lang:en OR has:images');
 });
 
 it('can compile a query with operators linked by AND', function () {
-    expect(query('php')->lang('en')->and->has('images')->compile())->toBe('php lang:en and has:images');
+    expect(query('php')->lang('en')->and->has('images')->compile())->toBe('php lang:en AND has:images');
 });
 
 it('can compile a query with operators linked by OR and AND', function () {
-    expect(query('php')->lang('en')->or->has('images')->and->has('videos')->compile())->toBe('php lang:en or has:images and has:videos');
+    expect(query('php')->lang('en')->or->has('images')->and->has('videos')->compile())->toBe('php lang:en OR has:images AND has:videos');
 });
 
 it('can compile a query with a group', function () {
     expect(query('php')->group(function (RuleBuilder $b) {
         $b->lang('en')->and->has('images');
-    })->compile())->toBe('php (lang:en and has:images)');
+    })->compile())->toBe('php (lang:en AND has:images)');
 });
 
 it('can compile a query with an or group', function () {
     expect(query('cats')->has('images')->or->group(function (RuleBuilder $b) {
         return $b->lang('en')->and->has('videos');
-    })->compile())->toBe('cats has:images or (lang:en and has:videos)');
+    })->compile())->toBe('cats has:images OR (lang:en AND has:videos)');
 });
 
 it('can compile a query with an and group', function () {
     expect(query('cats')->has('images')->and->group(function (RuleBuilder $b) {
         return $b->lang('en')->or->has('videos');
-    })->compile())->toBe('cats has:images and (lang:en or has:videos)');
+    })->compile())->toBe('cats has:images AND (lang:en OR has:videos)');
 });
 
 it('can compile a point radius operator', function () {
@@ -155,21 +155,21 @@ it('can group operators', function () {
             return $b->raw('cats')->raw('dogs');
         })->compile();
 
-    expect($rule)->toBe('(cats or dogs)');
+    expect($rule)->toBe('(cats OR dogs)');
 
     $rule = query()
         ->andGroup(function (RuleBuilder $b) {
             return $b->raw('cats')->raw('dogs');
         })->compile();
 
-    expect($rule)->toBe('(cats and dogs)');
+    expect($rule)->toBe('(cats AND dogs)');
 
     $rule = query()
         ->andNotGroup(function (RuleBuilder $b) {
             return $b->raw('cats')->raw('dogs')->isQuote();
         })->compile();
 
-    expect($rule)->toBe('(cats and dogs and -is:quote)');
+    expect($rule)->toBe('(cats AND dogs AND -is:quote)');
 });
 
 it('can compile a sample operator', function () {


### PR DESCRIPTION
Hi Felix,

this PR fixes logical operators error and TwitterException.php

- convert logical operators to uppercase
  ```
  Twitter error response: 
  Ambiguous use of or as a keyword. Use OR to logically join two clauses, or "or" to find occurrences of or in text
  ```
  
- Twitter is probably no longer attaching an error ID, but instead a `type` to the response. 
I also kept the ID if it was part of the response. 

  ```php
  // TwitterException::fromPayload
  
  $payload = [
    "value" => "__RULE_HERE__"
    "details" => array:1 [
      0 => "Ambiguous use of or as a keyword. Use OR to logically join two clauses, or "or" to find occurrences of or in text (at position 25)"
    ]
    "title" => "UnprocessableEntity"
    "type" => "https://api.twitter.com/2/problems/invalid-rules"
  ]
  ```


